### PR TITLE
Update DownloadSingleIntunepowershellScript.ps1

### DIFF
--- a/DownloadSingleIntunepowershellScript.ps1
+++ b/DownloadSingleIntunepowershellScript.ps1
@@ -167,4 +167,5 @@ $script64 = (Invoke-RestMethod -Uri $detailuri -Headers $authToken -Method Get).
 #Decode Base64 into Scripts
 $decodedscript = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($script64))
 #output File
-New-Item -Path . -Name $script.fileName -ItemType "file" -Value $decodedscript
+$scriptFileName = $($scriptarray | where {$_.id -eq $scriptid}).fileName
+New-Item -Path . -Name $scriptFileName -ItemType "file" -Value $decodedscript


### PR DESCRIPTION
Line 170 that saves the file with -Name $script.fileName uses the filename of the last script that was written out to the host to give a list of the ID's.

Using the ID as a value to lookup in the array I tested the following entered right above the New-Item and I believe it works well enough.

$scriptFileName = $($scriptarray | where {$_.id -eq $scriptid}).fileName

You would also need to change the $script.fileName to $scriptFileName to reflect the new variable that is holding the filename from the line above.